### PR TITLE
feat: ダミー餌と複数餌の設定を追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,17 +7,18 @@ import {
   setDirection,
   stepGame,
   type Direction,
+  type FoodItem,
   type GameState,
 } from './lib/snake';
 import { DEFAULT_SETTINGS, SPEED_VALUES, type GameSettings } from './lib/settings';
 import { Settings } from './Settings';
 
-type CellType = 'empty' | 'head' | 'body' | 'target';
+type CellType = 'empty' | 'head' | 'body' | 'food';
 type SnakeCellType = 'head' | 'body';
 
 function App() {
   const [gameState, setGameState] = useState<GameState>(() =>
-    createInitialState(DEFAULT_GRID_SIZE),
+    createInitialState(DEFAULT_GRID_SIZE, DEFAULT_SETTINGS),
   );
   const [hasStarted, setHasStarted] = useState(false);
   const [isPaused, setIsPaused] = useState(true);
@@ -91,12 +92,12 @@ function App() {
   );
 
   const restartGame = useCallback(() => {
-    setGameState(createInitialState(DEFAULT_GRID_SIZE));
+    setGameState(createInitialState(DEFAULT_GRID_SIZE, settings));
     setHasStarted(true);
     setIsPaused(false);
     setApiError(null);
     submittedRef.current = false;
-  }, []);
+  }, [settings]);
 
   const togglePause = useCallback(() => {
     if (!hasStarted || gameState.gameOver) {
@@ -181,9 +182,6 @@ function App() {
     };
   }, [applyDirection, gameState.gameOver, hasStarted, isSettingsOpen, restartGame, startIfNeeded, togglePause]);
 
-  const targetKey = gameState.targetCell
-    ? `${gameState.targetCell.x},${gameState.targetCell.y}`
-    : null;
   const targetLetter = getTargetLetter(gameState.targetLetterIndex);
 
   const snakeCells = useMemo(() => {
@@ -197,6 +195,17 @@ function App() {
     return map;
   }, [gameState.snake]);
 
+  const foodCells = useMemo(() => {
+    const map = new Map<string, FoodItem>();
+
+    gameState.foods.forEach((food) => {
+      const key = `${food.cell.x},${food.cell.y}`;
+      map.set(key, food);
+    });
+
+    return map;
+  }, [gameState.foods]);
+
   const cells = useMemo(() => {
     return Array.from({ length: DEFAULT_GRID_SIZE * DEFAULT_GRID_SIZE }, (_, i) => {
       const x = i % DEFAULT_GRID_SIZE;
@@ -205,9 +214,10 @@ function App() {
 
       let type: CellType = 'empty';
       const snakeType = snakeCells.get(key);
+      const food = foodCells.get(key);
 
-      if (targetKey === key) {
-        type = 'target';
+      if (food) {
+        type = 'food';
       }
 
       if (snakeType) {
@@ -217,10 +227,10 @@ function App() {
       let className = 'h-4 w-4 border border-stone-200 bg-board sm:h-5 sm:w-5';
       let content: string | null = null;
 
-      if (type === 'target') {
+      if (type === 'food') {
         className =
           'grid h-4 w-4 place-items-center border border-stone-200 bg-amber-300 text-[10px] font-bold text-stone-900 sm:h-5 sm:w-5 sm:text-xs';
-        content = targetLetter;
+        content = food?.letter ?? null;
       }
 
       if (type === 'body') {
@@ -233,7 +243,7 @@ function App() {
 
       return <div key={key} className={className}>{content}</div>;
     });
-  }, [snakeCells, targetKey, targetLetter]);
+  }, [foodCells, snakeCells]);
 
   const statusMessage = (() => {
     if (!hasStarted) {
@@ -338,7 +348,7 @@ function App() {
         </section>
 
         <p className="mt-4 text-sm text-stone-600">
-          操作: Arrow keys / WASD / Space。A から Z まで順番に集める。{apiError ? `API: ${apiError}` : 'API接続: OK'}
+          操作: Arrow keys / WASD / Space。A から Z まで順番に集め、ダミー文字に触れると終了。{apiError ? `API: ${apiError}` : 'API接続: OK'}
         </p>
       </section>
 

--- a/frontend/src/Settings.tsx
+++ b/frontend/src/Settings.tsx
@@ -1,5 +1,5 @@
-import type { GameSettings, GameSpeed } from './lib/settings';
-import { SPEED_LABELS } from './lib/settings';
+import type { DummyCount, GameSettings, GameSpeed } from './lib/settings';
+import { DUMMY_COUNT_LABELS, SPEED_LABELS } from './lib/settings';
 
 type SettingsProps = {
   isOpen: boolean;
@@ -15,6 +15,10 @@ export function Settings({ isOpen, settings, onClose, onSave }: SettingsProps) {
 
   const handleSpeedChange = (speed: GameSpeed) => {
     onSave({ ...settings, speed });
+  };
+
+  const handleDummyCountChange = (dummyCount: DummyCount) => {
+    onSave({ ...settings, dummyCount });
   };
 
   return (
@@ -58,6 +62,26 @@ export function Settings({ isOpen, settings, onClose, onSave }: SettingsProps) {
                     className="h-4 w-4"
                   />
                   <span className="text-sm">{SPEED_LABELS[speed]}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <h3 className="mb-2 text-sm font-medium text-stone-700">ダミーの数</h3>
+            <p className="mb-2 text-xs text-stone-500">変更は次回リスタートから反映されます。</p>
+            <div className="space-y-2">
+              {(Object.keys(DUMMY_COUNT_LABELS) as unknown as DummyCount[]).map((dummyCount) => (
+                <label key={dummyCount} className="flex cursor-pointer items-center gap-2">
+                  <input
+                    type="radio"
+                    name="dummyCount"
+                    value={dummyCount}
+                    checked={settings.dummyCount === dummyCount}
+                    onChange={() => handleDummyCountChange(dummyCount)}
+                    className="h-4 w-4"
+                  />
+                  <span className="text-sm">{DUMMY_COUNT_LABELS[dummyCount]}</span>
                 </label>
               ))}
             </div>

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -1,14 +1,14 @@
 export type GameSpeed = 'slow' | 'normal' | 'fast';
-export type QuestionFormat = 'sequential' | 'random';
+export type DummyCount = 2 | 3 | 4 | 5;
 
 export type GameSettings = {
   speed: GameSpeed;
-  questionFormat: QuestionFormat;
+  dummyCount: DummyCount;
 };
 
 export const DEFAULT_SETTINGS: GameSettings = {
   speed: 'normal',
-  questionFormat: 'sequential',
+  dummyCount: 2,
 };
 
 export const SPEED_VALUES: Record<GameSpeed, number> = {
@@ -23,7 +23,9 @@ export const SPEED_LABELS: Record<GameSpeed, string> = {
   fast: '速い (Fast)',
 };
 
-export const QUESTION_FORMAT_LABELS: Record<QuestionFormat, string> = {
-  sequential: 'A-Z順番 (Sequential)',
-  random: 'ランダム (Random)',
+export const DUMMY_COUNT_LABELS: Record<DummyCount, string> = {
+  2: '2個 (合計3個)',
+  3: '3個 (合計4個)',
+  4: '4個 (合計5個)',
+  5: '5個 (合計6個)',
 };

--- a/frontend/src/lib/snake.test.ts
+++ b/frontend/src/lib/snake.test.ts
@@ -2,17 +2,22 @@ import { describe, expect, it } from 'vitest';
 import {
   createInitialState,
   getTargetLetter,
+  placeFoods,
   placeTargetCell,
   stepGame,
   type GameState,
 } from './snake';
+import { DEFAULT_SETTINGS } from './settings';
 
 describe('alphabet snake rules', () => {
-  it('初期状態のターゲット文字はA', () => {
-    const state = createInitialState(6, () => 0); // 乱数を固定して初期配置を安定化する。
+  it('初期状態で正解1個とダミー2個が配置される', () => {
+    const state = createInitialState(6, DEFAULT_SETTINGS, () => 0); // 乱数を固定して初期配置を安定化する。
     expect(state.targetLetterIndex).toBe(0);
     expect(getTargetLetter(state.targetLetterIndex)).toBe('A');
-    expect(state.targetCell).not.toBeNull();
+    expect(state.dummyCount).toBe(2);
+    expect(state.foods).toHaveLength(3);
+    expect(state.foods.filter((food) => food.kind === 'target')).toHaveLength(1);
+    expect(state.foods.filter((food) => food.kind === 'dummy')).toHaveLength(2);
   });
 
   it('ターゲット取得時に成長・加点・文字進行する', () => {
@@ -23,9 +28,14 @@ describe('alphabet snake rules', () => {
       ],
       direction: 'right',
       pendingDirection: 'right',
-      targetCell: { x: 2, y: 1 }, // 次ヘッド位置にターゲットを置く。
+      foods: [
+        { cell: { x: 2, y: 1 }, letter: 'A', kind: 'target' }, // 次ヘッド位置に正解を置く。
+        { cell: { x: 5, y: 5 }, letter: 'B', kind: 'dummy' },
+        { cell: { x: 4, y: 4 }, letter: 'C', kind: 'dummy' },
+      ],
       targetLetterIndex: 0,
       completedCycles: 0,
+      dummyCount: 2,
       score: 0,
       gameOver: false,
     };
@@ -35,6 +45,7 @@ describe('alphabet snake rules', () => {
     expect(next.score).toBe(1);
     expect(next.targetLetterIndex).toBe(1);
     expect(getTargetLetter(next.targetLetterIndex)).toBe('B');
+    expect(next.foods.filter((food) => food.kind === 'dummy')).toHaveLength(2);
     expect(next.gameOver).toBe(false);
   });
 
@@ -46,9 +57,14 @@ describe('alphabet snake rules', () => {
       ],
       direction: 'right',
       pendingDirection: 'right',
-      targetCell: { x: 5, y: 5 }, // 到達しない位置に置く。
+      foods: [
+        { cell: { x: 5, y: 5 }, letter: 'A', kind: 'target' }, // 到達しない位置に正解を置く。
+        { cell: { x: 6, y: 6 }, letter: 'B', kind: 'dummy' },
+        { cell: { x: 7, y: 7 }, letter: 'C', kind: 'dummy' },
+      ],
       targetLetterIndex: 0,
       completedCycles: 0,
+      dummyCount: 2,
       score: 0,
       gameOver: false,
     };
@@ -67,9 +83,14 @@ describe('alphabet snake rules', () => {
       ],
       direction: 'right',
       pendingDirection: 'right',
-      targetCell: { x: 2, y: 1 }, // 取得を確実に発生させる。
+      foods: [
+        { cell: { x: 2, y: 1 }, letter: 'Z', kind: 'target' }, // 取得を確実に発生させる。
+        { cell: { x: 5, y: 5 }, letter: 'A', kind: 'dummy' },
+        { cell: { x: 4, y: 4 }, letter: 'B', kind: 'dummy' },
+      ],
       targetLetterIndex: 25,
       completedCycles: 0,
+      dummyCount: 2,
       score: 10,
       gameOver: false,
     };
@@ -79,6 +100,12 @@ describe('alphabet snake rules', () => {
     expect(getTargetLetter(next.targetLetterIndex)).toBe('A');
     expect(next.completedCycles).toBe(1);
     expect(next.score).toBe(11);
+  });
+
+  it('ダミー数を変えた初期化では正解1個に加えて同数のダミーが出る', () => {
+    const state = createInitialState(8, { ...DEFAULT_SETTINGS, dummyCount: 5 }, () => 0); // 最大設定で個数を確認する。
+    expect(state.foods).toHaveLength(6);
+    expect(state.foods.filter((food) => food.kind === 'dummy')).toHaveLength(5);
   });
 
   it('ターゲット配置は蛇と重ならない', () => {
@@ -93,6 +120,63 @@ describe('alphabet snake rules', () => {
     expect(overlapped).toBe(false);
   });
 
+  it('複数餌の配置は正解文字を含み、ダミー文字は重複しない', () => {
+    const foods = placeFoods(
+      [
+        { x: 1, y: 1 },
+        { x: 0, y: 1 },
+      ],
+      0,
+      3,
+      6,
+      () => 0,
+    ); // 常に先頭候補を選び、生成内容を安定化する。
+    const dummyLetters = foods?.filter((food) => food.kind === 'dummy').map((food) => food.letter) ?? [];
+    expect(foods?.find((food) => food.kind === 'target')?.letter).toBe('A');
+    expect(new Set(dummyLetters).size).toBe(dummyLetters.length);
+    expect(dummyLetters).not.toContain('A');
+  });
+
+  it('空きマスが少ない場合は正解を優先して置けるだけ配置する', () => {
+    const foods = placeFoods(
+      [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 0, y: 1 },
+      ],
+      0,
+      2,
+      2,
+      () => 0,
+    ); // 2x2盤面の最後の1マスだけが空いている状態を作る。
+    expect(foods).toHaveLength(1);
+    expect(foods?.[0].kind).toBe('target');
+  });
+
+  it('ダミーに当たるとゲームオーバーになる', () => {
+    const state: GameState = {
+      snake: [
+        { x: 1, y: 1 },
+        { x: 0, y: 1 },
+      ],
+      direction: 'right',
+      pendingDirection: 'right',
+      foods: [
+        { cell: { x: 2, y: 1 }, letter: 'B', kind: 'dummy' }, // 次ヘッド位置にダミーを置く。
+        { cell: { x: 5, y: 5 }, letter: 'A', kind: 'target' },
+      ],
+      targetLetterIndex: 0,
+      completedCycles: 0,
+      dummyCount: 2,
+      score: 0,
+      gameOver: false,
+    };
+
+    const next = stepGame(state, 6, () => 0);
+    expect(next.gameOver).toBe(true);
+    expect(next.score).toBe(0);
+  });
+
   it('壁衝突でゲームオーバーになる', () => {
     const state: GameState = {
       snake: [
@@ -101,9 +185,13 @@ describe('alphabet snake rules', () => {
       ],
       direction: 'up',
       pendingDirection: 'up',
-      targetCell: { x: 0, y: 2 },
+      foods: [
+        { cell: { x: 0, y: 2 }, letter: 'A', kind: 'target' },
+        { cell: { x: 2, y: 2 }, letter: 'B', kind: 'dummy' },
+      ],
       targetLetterIndex: 0,
       completedCycles: 0,
+      dummyCount: 2,
       score: 0,
       gameOver: false,
     };
@@ -122,9 +210,13 @@ describe('alphabet snake rules', () => {
       ],
       direction: 'up',
       pendingDirection: 'up',
-      targetCell: { x: 4, y: 4 },
+      foods: [
+        { cell: { x: 4, y: 4 }, letter: 'D', kind: 'target' },
+        { cell: { x: 5, y: 5 }, letter: 'A', kind: 'dummy' },
+      ],
       targetLetterIndex: 3,
       completedCycles: 0,
+      dummyCount: 2,
       score: 2,
       gameOver: false,
     };

--- a/frontend/src/lib/snake.ts
+++ b/frontend/src/lib/snake.ts
@@ -1,3 +1,6 @@
+import type { DummyCount, GameSettings } from './settings';
+import { DEFAULT_SETTINGS } from './settings';
+
 export type Direction = 'up' | 'down' | 'left' | 'right';
 
 export type Point = {
@@ -5,13 +8,22 @@ export type Point = {
   y: number;
 };
 
+export type FoodKind = 'target' | 'dummy';
+
+export type FoodItem = {
+  cell: Point;
+  letter: string;
+  kind: FoodKind;
+};
+
 export type GameState = {
   snake: Point[];
   direction: Direction;
   pendingDirection: Direction;
-  targetCell: Point | null;
+  foods: FoodItem[];
   targetLetterIndex: number;
   completedCycles: number;
+  dummyCount: DummyCount;
   score: number;
   gameOver: boolean;
 };
@@ -35,6 +47,7 @@ const OPPOSITE_DIRECTIONS: Record<Direction, Direction> = {
 
 export function createInitialState(
   gridSize = DEFAULT_GRID_SIZE,
+  settings: GameSettings = DEFAULT_SETTINGS,
   rng: () => number = Math.random,
 ): GameState {
   const head = {
@@ -43,16 +56,18 @@ export function createInitialState(
   };
 
   const snake = [head, { x: head.x - 1, y: head.y }];
+  const foods = placeFoods(snake, 0, settings.dummyCount, gridSize, rng);
 
   return {
     snake,
     direction: 'right',
     pendingDirection: 'right',
-    targetCell: placeTargetCell(snake, gridSize, rng),
+    foods: foods ?? [],
     targetLetterIndex: 0,
     completedCycles: 0,
+    dummyCount: settings.dummyCount,
     score: 0,
-    gameOver: false,
+    gameOver: foods === null,
   };
 }
 
@@ -61,11 +76,10 @@ export function getTargetLetter(targetLetterIndex: number): string {
   return ALPHABET[normalizedIndex];
 }
 
-export function placeTargetCell(
+function getFreeCells(
   snake: Point[],
   gridSize = DEFAULT_GRID_SIZE,
-  rng: () => number = Math.random,
-): Point | null {
+): Point[] {
   const occupied = new Set(snake.map((segment) => `${segment.x},${segment.y}`));
   const freeCells: Point[] = [];
 
@@ -78,12 +92,69 @@ export function placeTargetCell(
     }
   }
 
-  if (freeCells.length === 0) {
+  return freeCells;
+}
+
+function takeRandomItem<T>(items: T[], rng: () => number): T | null {
+  if (items.length === 0) {
     return null;
   }
 
-  const index = Math.floor(rng() * freeCells.length);
-  return freeCells[index];
+  const index = Math.floor(rng() * items.length);
+  const [selected] = items.splice(index, 1);
+  return selected;
+}
+
+export function placeTargetCell(
+  snake: Point[],
+  gridSize = DEFAULT_GRID_SIZE,
+  rng: () => number = Math.random,
+): Point | null {
+  const freeCells = getFreeCells(snake, gridSize);
+  return takeRandomItem(freeCells, rng);
+}
+
+export function placeFoods(
+  snake: Point[],
+  targetLetterIndex: number,
+  dummyCount: DummyCount,
+  gridSize = DEFAULT_GRID_SIZE,
+  rng: () => number = Math.random,
+): FoodItem[] | null {
+  const freeCells = getFreeCells(snake, gridSize);
+  const targetCell = takeRandomItem(freeCells, rng);
+
+  if (targetCell === null) {
+    return null;
+  }
+
+  const targetLetter = getTargetLetter(targetLetterIndex);
+  const foods: FoodItem[] = [
+    {
+      cell: targetCell,
+      letter: targetLetter,
+      kind: 'target',
+    },
+  ];
+
+  const dummyLetters = ALPHABET.split('').filter((letter) => letter !== targetLetter);
+
+  for (let i = 0; i < dummyCount; i += 1) {
+    const dummyCell = takeRandomItem(freeCells, rng);
+    const dummyLetter = takeRandomItem(dummyLetters, rng);
+
+    if (dummyCell === null || dummyLetter === null) {
+      break;
+    }
+
+    foods.push({
+      cell: dummyCell,
+      letter: dummyLetter,
+      kind: 'dummy',
+    });
+  }
+
+  return foods;
 }
 
 export function setDirection(state: GameState, nextDirection: Direction): GameState {
@@ -101,7 +172,6 @@ export function stepGame(
   state: GameState,
   gridSize = DEFAULT_GRID_SIZE,
   rng: () => number = Math.random,
-  questionFormat: 'sequential' | 'random' = 'sequential',
 ): GameState {
   if (state.gameOver) {
     return state;
@@ -127,10 +197,19 @@ export function stepGame(
     };
   }
 
-  const ateTarget =
-    state.targetCell !== null &&
-    nextHead.x === state.targetCell.x &&
-    nextHead.y === state.targetCell.y;
+  const hitFood =
+    state.foods.find(
+      (food) => nextHead.x === food.cell.x && nextHead.y === food.cell.y,
+    ) ?? null;
+  const ateTarget = hitFood?.kind === 'target';
+  const hitDummy = hitFood?.kind === 'dummy';
+
+  if (hitDummy) {
+    return {
+      ...state,
+      gameOver: true,
+    };
+  }
 
   // 食べていないときは末尾が移動するため、衝突判定から末尾を除外する。
   const bodyToCheck = ateTarget ? state.snake : state.snake.slice(0, -1);
@@ -153,25 +232,20 @@ export function stepGame(
 
   let nextTargetLetterIndex = state.targetLetterIndex;
   let nextCompletedCycles = state.completedCycles;
-  let nextTargetCell = state.targetCell;
+  let nextFoods = state.foods;
   let nextScore = state.score;
 
   if (ateTarget) {
     const isCycleCompleted = state.targetLetterIndex === ALPHABET.length - 1;
-    if (questionFormat === 'random') {
-      // Ensure a different letter is selected to avoid confusion
-      if (ALPHABET.length > 1) {
-        const availableIndices = Array.from({ length: ALPHABET.length }, (_, i) => i)
-          .filter((i) => i !== state.targetLetterIndex);
-        nextTargetLetterIndex = availableIndices[Math.floor(rng() * availableIndices.length)];
-      } else {
-        nextTargetLetterIndex = 0;
-      }
-    } else {
-      nextTargetLetterIndex = (state.targetLetterIndex + 1) % ALPHABET.length;
-    }
+    nextTargetLetterIndex = (state.targetLetterIndex + 1) % ALPHABET.length;
     nextCompletedCycles = isCycleCompleted ? state.completedCycles + 1 : state.completedCycles;
-    nextTargetCell = placeTargetCell(nextSnake, gridSize, rng);
+    nextFoods = placeFoods(
+      nextSnake,
+      nextTargetLetterIndex,
+      state.dummyCount,
+      gridSize,
+      rng,
+    ) ?? [];
     nextScore += 1;
   }
 
@@ -179,10 +253,11 @@ export function stepGame(
     snake: nextSnake,
     direction: state.pendingDirection,
     pendingDirection: state.pendingDirection,
-    targetCell: nextTargetCell,
+    foods: nextFoods,
     targetLetterIndex: nextTargetLetterIndex,
     completedCycles: nextCompletedCycles,
+    dummyCount: state.dummyCount,
     score: nextScore,
-    gameOver: nextTargetCell === null,
+    gameOver: ateTarget && nextFoods.length === 0,
   };
 }


### PR DESCRIPTION
## 概要
- 正解 1 個 + ダミー複数個の餌を盤面に表示するよう変更
- 設定画面でダミー数を 2 / 3 / 4 / 5 から選べるよう追加
- ダミーに触れた場合はゲームオーバーにし、設定変更は次回リスタートから反映

## テスト
- \
> frontend@0.0.0 test
> vitest run


 RUN  v4.0.18 /Users/tokimasatakuya/Dev/snake-game/frontend

 ✓ src/lib/snake.test.ts (11 tests) 3ms

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  09:57:41
   Duration  88ms (transform 23ms, setup 0ms, import 31ms, tests 3ms, environment 0ms)
- \
> frontend@0.0.0 lint
> eslint .
- \
> frontend@0.0.0 build
> tsc -b && vite build

vite v7.3.1 building client environment for production...
transforming...
✓ 33 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                   0.46 kB │ gzip:  0.29 kB
dist/assets/index-DSJ1h3dk.css   10.08 kB │ gzip:  2.73 kB
dist/assets/index-BRx7zTw6.js   203.49 kB │ gzip: 64.40 kB
✓ built in 564ms

## 補足
- 初期値はダミー 2 個で、初期盤面は合計 3 個の餌です。